### PR TITLE
Resolved #6: Added payload_in

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,3 +5,7 @@ Initial release version
 1.1.0
 
 Added option to use linear weigthed averages.
+
+1.2.0
+
+Added original payload as payload_in.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ manipulate it:
 - "clear": Removes all stored numbers.
 - "count": Counts the number of currently stored numbers.
 
+The original payload is returned as payload_in.
 
 ## Links
 

--- a/moving-average.html
+++ b/moving-average.html
@@ -121,4 +121,5 @@
             <p>If the <code>count</code> command is used, the payload is not set to the current moving average, but to the amount of numbers currently in memory.</p>
         </dd>
     </dl>
+    <p>The original payload is returned as <code>payload_in</code>.</p>
 </script>

--- a/moving-average.js
+++ b/moving-average.js
@@ -88,6 +88,7 @@ module.exports = function(RED) {
                     break;
             }
         
+            msg.payload_in = msg.payload;
             msg.payload = result;
             node.send(msg);
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-moving-average",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A Node-RED node to calculate moving averages.",
   "keywords": [
     "node-red"


### PR DESCRIPTION
The original payload is now returned as payload_in.
This provides an additional method to determine what value was added or to differentiate between commands sent without duplicating the command to another property in the message object.