### PR TITLE
Resolved #8: Added min and max commands.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,3 +9,7 @@ Added option to use linear weigthed averages.
 1.2.0
 
 Added original payload as payload_in.
+
+1.3.0
+
+Added "min" and "max" commands.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ manipulate it:
 - "pop": Removes the oldest stored number.
 - "clear": Removes all stored numbers.
 - "count": Counts the number of currently stored numbers.
+- "min": Returns the minimum of the currently stored numbers.
+- "max": Returns the maximum of the currently stored numbers.
 
 The original payload is returned as payload_in.
 

--- a/moving-average.html
+++ b/moving-average.html
@@ -97,14 +97,12 @@
             <p>When a string is received, it is interpreted as a command for
             the node:</p>
                 <ul>
-                    <li><code>get</code>: no number is added, only returns the
-                    current moving average.</li>
-                    <li><code>count</code>: no number is added, returns the
-                    number of numbers currently stored.</li>
-                    <li><code>pop</code>: no number is added but the oldest
-                    received number is removed.</li>
-                    <li><code>clear</code>: all stored numbers for the current
-                    topic are removed.</li>
+                    <li><code>get</code>: no number is added, only returns the current moving average.</li>
+                    <li><code>count</code>: no number is added, returns the number of numbers currently stored.</li>
+                    <li><code>min</code>: no number is added, returns the minimum of the numbers currently stored.</li>
+                    <li><code>max</code>: no number is added, returns the maximum of the numbers currently stored.</li>
+                    <li><code>pop</code>: no number is added but the oldest received number is removed.</li>
+                    <li><code>clear</code>: all stored numbers for the current topic are removed.</li>
                 </ul>
         </dd>
     </dl>
@@ -119,6 +117,7 @@
             <p>If there is no average, (for example after the <code>clear</code> command is used) the payload is set to 0.</p>
             <p>If you want to get the current moving average without adding a number, set a message with <code>get</code> as the payload.</p>
             <p>If the <code>count</code> command is used, the payload is not set to the current moving average, but to the amount of numbers currently in memory.</p>
+            <p>If the <code>min</code> or <code>max</code> command is used, the payload is not set to the current moving average, but to the minimum or the maximum of the numbers currently in memory.</p>
         </dd>
     </dl>
     <p>The original payload is returned as <code>payload_in</code>.</p>

--- a/moving-average.html
+++ b/moving-average.html
@@ -99,8 +99,8 @@
                 <ul>
                     <li><code>get</code>: no number is added, only returns the current moving average.</li>
                     <li><code>count</code>: no number is added, returns the number of numbers currently stored.</li>
-                    <li><code>min</code>: no number is added, returns the minimum of the numbers currently stored.</li>
-                    <li><code>max</code>: no number is added, returns the maximum of the numbers currently stored.</li>
+                    <li><code>min</code>: no number is added, returns the minimum of the numbers currently stored. Returns positive infinity if no values are stored.</li>
+                    <li><code>max</code>: no number is added, returns the maximum of the numbers currently stored. Returns negative infinity if no values are stored.</li>
                     <li><code>pop</code>: no number is added but the oldest received number is removed.</li>
                     <li><code>clear</code>: all stored numbers for the current topic are removed.</li>
                 </ul>

--- a/moving-average.js
+++ b/moving-average.js
@@ -34,12 +34,14 @@ const parsePayload = (payload, error) => {
             switch (payload) {
                 case "get":
                 case "count":
+                case "min":
+                case "max":
                 case "pop":
                 case "clear":
                     return [0, payload];
                 
                 default:
-                    error(`Invalid payload: expected number, boolean, "get", "count", "pop", "clear"`);
+                    error(`Invalid payload: expected number, boolean, "get", "count", "min", "max", "pop", "clear"`);
                     return [0, "get"];
             }
 
@@ -81,6 +83,14 @@ module.exports = function(RED) {
             switch (action) {
                 case 'count':
                     result = data.length;
+                    break;
+                    
+                case 'min':
+                    result = Math.min(...data);
+                    break;
+                    
+                case 'max':
+                    result = Math.max(...data);
                     break;
                     
                 default:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-moving-average",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A Node-RED node to calculate moving averages.",
   "keywords": [
     "node-red"


### PR DESCRIPTION
New feature: `min` and `max` commands.
Return the minimum and maximum of the currently stored values.
Bumped version to 1.3.0.

Closes #8 